### PR TITLE
Fixed exception when temporary cannot be create

### DIFF
--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -7,11 +7,11 @@ use function sprintf;
 final class RuntimeException extends \RuntimeException implements ExceptionInterface
 {
     /**
-     * @param string $file
+     * @param string $dir
      * @return self
      */
-    public static function unableToCreateTemporaryFile($file)
+    public static function unableToCreateTemporaryFile($dir)
     {
-        return new self(sprintf('Could not create temporary file "%s"', $file));
+        return new self(sprintf('Could not create temporary file in directory "%s"', $dir));
     }
 }

--- a/src/FileWriter.php
+++ b/src/FileWriter.php
@@ -29,7 +29,7 @@ final class FileWriter
         $tmp = tempnam($dir, 'wsw');
 
         if ($tmp === false) {
-            throw Exception\RuntimeException::unableToCreateTemporaryFile($tmp);
+            throw Exception\RuntimeException::unableToCreateTemporaryFile($dir);
         }
 
         if (file_put_contents($tmp, $content) === false) {

--- a/test/Exception/RuntimeExceptionTest.php
+++ b/test/Exception/RuntimeExceptionTest.php
@@ -11,10 +11,10 @@ class RuntimeExceptionTest extends TestCase
 {
     public function testException()
     {
-        $file = uniqid('file_', true);
-        $exception = RuntimeException::unableToCreateTemporaryFile($file);
+        $dir = uniqid('dir_', true);
+        $exception = RuntimeException::unableToCreateTemporaryFile($dir);
 
         self::assertInstanceOf(RuntimeException::class, $exception);
-        self::assertContains($file, $exception->getMessage());
+        self::assertContains($dir, $exception->getMessage());
     }
 }


### PR DESCRIPTION
We do not know the temporary file name, as it is generated automatically
so the exception message can just contain direcotry name, were we tried
create the temporary file.

Before we pass to the exception boolean false, when string was expected.