### PR TITLE
[v2.0] Drop support of PHP 5.6, 7.0 and 7.1

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 15
       matrix:
         operating-system: [macOS-latest]
-        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.1', '7.2', '7.3', '7.4']
     name: PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}
     steps:
       - name: Checkout

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 15
       matrix:
         operating-system: [macOS-latest]
-        php-versions: ['7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.2', '7.3', '7.4']
     name: PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpunit.result.cache
 /clover.xml
 /composer.lock
 /coveralls-upload.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,6 @@ matrix:
       env:
         - PHP_VERSION=7.3.11
         - PHP_DIR=php73
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
-      env:
-        - DEPS=latest
     - php: 7.2
       env:
         - DEPS=lowest

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,18 +17,6 @@ matrix:
       env:
         - PHP_VERSION=7.3.11
         - PHP_DIR=php73
-    - php: 5.6
-      env:
-        - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7.0
-      env:
-        - DEPS=lowest
-    - php: 7.0
-      env:
-        - DEPS=latest
     - php: 7.1
       env:
         - DEPS=lowest

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
         "race condition"
     ],
     "require": {
-        "php": "^5.6 || ^7.0"
+        "php": "^7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.16",
-        "squizlabs/php_codesniffer": "^3.5.2"
+        "phpunit/phpunit": "^7.5.17 || ^8.4.3",
+        "webimpress/coding-standard": "dev-develop"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
         "race condition"
     ],
     "require": {
-        "php": "^7.1"
+        "php": "^7.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5.17 || ^8.4.3",
+        "phpunit/phpunit": "^8.4.3",
         "webimpress/coding-standard": "dev-develop"
     },
     "autoload": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0"?>
 <ruleset>
-    <rule ref="PSR12"/>
+    <rule ref="vendor/webimpress/coding-standard/ruleset.xml"/>
 
     <!-- Display progress -->
     <arg value="p"/>

--- a/src/Exception/ChmodException.php
+++ b/src/Exception/ChmodException.php
@@ -5,11 +5,24 @@ declare(strict_types=1);
 namespace Webimpress\SafeWriter\Exception;
 
 use RuntimeException as PhpRuntimeException;
+use Throwable;
 
 use function sprintf;
 
 final class ChmodException extends PhpRuntimeException implements ExceptionInterface
 {
+    /**
+     * @param string $message
+     * @param int $code
+     */
+    private function __construct($message = '', $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @internal
+     */
     public static function unableToChangeChmod(string $file) : self
     {
         return new self(sprintf('Could not change chmod of the file "%s"', $file));

--- a/src/Exception/ChmodException.php
+++ b/src/Exception/ChmodException.php
@@ -1,16 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Webimpress\SafeWriter\Exception;
+
+use RuntimeException as PhpRuntimeException;
 
 use function sprintf;
 
-final class ChmodException extends \RuntimeException implements ExceptionInterface
+final class ChmodException extends PhpRuntimeException implements ExceptionInterface
 {
-    /**
-     * @param string $file
-     * @return self
-     */
-    public static function unableToChangeChmod($file)
+    public static function unableToChangeChmod(string $file) : self
     {
         return new self(sprintf('Could not change chmod of the file "%s"', $file));
     }

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Webimpress\SafeWriter\Exception;
 
-interface ExceptionInterface
+use Throwable;
+
+interface ExceptionInterface extends Throwable
 {
 }

--- a/src/Exception/RenameException.php
+++ b/src/Exception/RenameException.php
@@ -5,11 +5,24 @@ declare(strict_types=1);
 namespace Webimpress\SafeWriter\Exception;
 
 use RuntimeException as PhpRuntimeException;
+use Throwable;
 
 use function sprintf;
 
 final class RenameException extends PhpRuntimeException implements ExceptionInterface
 {
+    /**
+     * @param string $message
+     * @param int $code
+     */
+    private function __construct($message = '', $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @internal
+     */
     public static function unableToMoveFile(string $source, string $target) : self
     {
         return new self(sprintf(

--- a/src/Exception/RenameException.php
+++ b/src/Exception/RenameException.php
@@ -1,17 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Webimpress\SafeWriter\Exception;
+
+use RuntimeException as PhpRuntimeException;
 
 use function sprintf;
 
-final class RenameException extends \RuntimeException implements ExceptionInterface
+final class RenameException extends PhpRuntimeException implements ExceptionInterface
 {
-    /**
-     * @param string $source
-     * @param string $target
-     * @return self
-     */
-    public static function unableToMoveFile($source, $target)
+    public static function unableToMoveFile(string $source, string $target) : self
     {
         return new self(sprintf(
             'Could not move file "%s" to location "%s": '

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,16 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Webimpress\SafeWriter\Exception;
+
+use RuntimeException as PhpRuntimeException;
 
 use function sprintf;
 
-final class RuntimeException extends \RuntimeException implements ExceptionInterface
+final class RuntimeException extends PhpRuntimeException implements ExceptionInterface
 {
-    /**
-     * @param string $dir
-     * @return self
-     */
-    public static function unableToCreateTemporaryFile($dir)
+    public static function unableToCreateTemporaryFile(string $dir) : self
     {
         return new self(sprintf('Could not create temporary file in directory "%s"', $dir));
     }

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -5,11 +5,24 @@ declare(strict_types=1);
 namespace Webimpress\SafeWriter\Exception;
 
 use RuntimeException as PhpRuntimeException;
+use Throwable;
 
 use function sprintf;
 
 final class RuntimeException extends PhpRuntimeException implements ExceptionInterface
 {
+    /**
+     * @param string $message
+     * @param int $code
+     */
+    private function __construct($message = '', $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @internal
+     */
     public static function unableToCreateTemporaryFile(string $dir) : self
     {
         return new self(sprintf('Could not create temporary file in directory "%s"', $dir));

--- a/src/Exception/WriteContentException.php
+++ b/src/Exception/WriteContentException.php
@@ -5,11 +5,24 @@ declare(strict_types=1);
 namespace Webimpress\SafeWriter\Exception;
 
 use RuntimeException as PhpRuntimeException;
+use Throwable;
 
 use function sprintf;
 
 final class WriteContentException extends PhpRuntimeException implements ExceptionInterface
 {
+    /**
+     * @param string $message
+     * @param int $code
+     */
+    private function __construct($message = '', $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @internal
+     */
     public static function unableToWriteContent(string $file) : self
     {
         return new self(sprintf('Could not write content to the file "%s"', $file));

--- a/src/Exception/WriteContentException.php
+++ b/src/Exception/WriteContentException.php
@@ -1,16 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Webimpress\SafeWriter\Exception;
+
+use RuntimeException as PhpRuntimeException;
 
 use function sprintf;
 
-final class WriteContentException extends \RuntimeException implements ExceptionInterface
+final class WriteContentException extends PhpRuntimeException implements ExceptionInterface
 {
-    /**
-     * @param string $file
-     * @return self
-     */
-    public static function unableToWriteContent($file)
+    public static function unableToWriteContent(string $file) : self
     {
         return new self(sprintf('Could not write content to the file "%s"', $file));
     }

--- a/src/FileWriter.php
+++ b/src/FileWriter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Webimpress\SafeWriter;
 
 use function chmod;
@@ -17,13 +19,9 @@ use const PHP_OS;
 final class FileWriter
 {
     /**
-     * @param string $file
-     * @param string $content
-     * @param int $chmod
-     * @return void
      * @throws Exception\ExceptionInterface
      */
-    public static function writeFile($file, $content, $chmod = 0666)
+    public static function writeFile(string $file, string $content, int $chmod = 0666) : void
     {
         $dir = dirname($file);
         $tmp = tempnam($dir, 'wsw');

--- a/test/Exception/ChmodExceptionTest.php
+++ b/test/Exception/ChmodExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WebimpressTest\SafeWriter\Exception;
 
 use PHPUnit\Framework\TestCase;
@@ -9,12 +11,12 @@ use function uniqid;
 
 class ChmodExceptionTest extends TestCase
 {
-    public function testException()
+    public function testException() : void
     {
         $file = uniqid('file_', true);
         $exception = ChmodException::unableToChangeChmod($file);
 
         self::assertInstanceOf(ChmodException::class, $exception);
-        self::assertContains($file, $exception->getMessage());
+        self::assertStringContainsString($file, $exception->getMessage());
     }
 }

--- a/test/Exception/RenameExceptionTest.php
+++ b/test/Exception/RenameExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WebimpressTest\SafeWriter\Exception;
 
 use PHPUnit\Framework\TestCase;
@@ -9,14 +11,14 @@ use function uniqid;
 
 class RenameExceptionTest extends TestCase
 {
-    public function testException()
+    public function testException() : void
     {
         $file = uniqid('file_', true);
         $target = __DIR__ . '/' . uniqid('file_', true);
         $exception = RenameException::unableToMoveFile($file, $target);
 
         self::assertInstanceOf(RenameException::class, $exception);
-        self::assertContains($file, $exception->getMessage());
-        self::assertContains($target, $exception->getMessage());
+        self::assertStringContainsString($file, $exception->getMessage());
+        self::assertStringContainsString($target, $exception->getMessage());
     }
 }

--- a/test/Exception/RuntimeExceptionTest.php
+++ b/test/Exception/RuntimeExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WebimpressTest\SafeWriter\Exception;
 
 use PHPUnit\Framework\TestCase;
@@ -9,12 +11,12 @@ use function uniqid;
 
 class RuntimeExceptionTest extends TestCase
 {
-    public function testException()
+    public function testException() : void
     {
         $dir = uniqid('dir_', true);
         $exception = RuntimeException::unableToCreateTemporaryFile($dir);
 
         self::assertInstanceOf(RuntimeException::class, $exception);
-        self::assertContains($dir, $exception->getMessage());
+        self::assertStringContainsString($dir, $exception->getMessage());
     }
 }

--- a/test/Exception/WriteContentExceptionTest.php
+++ b/test/Exception/WriteContentExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WebimpressTest\SafeWriter\Exception;
 
 use PHPUnit\Framework\TestCase;
@@ -9,12 +11,12 @@ use function uniqid;
 
 class WriteContentExceptionTest extends TestCase
 {
-    public function testException()
+    public function testException() : void
     {
         $file = uniqid('file_', true);
         $exception = WriteContentException::unableToWriteContent($file);
 
         self::assertInstanceOf(WriteContentException::class, $exception);
-        self::assertContains($file, $exception->getMessage());
+        self::assertStringContainsString($file, $exception->getMessage());
     }
 }

--- a/test/ExceptionTest.php
+++ b/test/ExceptionTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace WebimpressTest\SafeWriter;
 
+use Error;
 use Generator;
 use PHPUnit\Framework\TestCase;
 use Webimpress\SafeWriter\Exception\ExceptionInterface;
 
 use function basename;
 use function glob;
+use function interface_exists;
 use function is_a;
 use function strrpos;
 use function substr;
@@ -35,5 +37,19 @@ class ExceptionTest extends TestCase
     {
         self::assertStringContainsString('Exception', $exception);
         self::assertTrue(is_a($exception, ExceptionInterface::class, true));
+    }
+
+    /**
+     * @dataProvider exception
+     */
+    public function testExceptionIsNotInstantiable(string $exception) : void
+    {
+        if (interface_exists($exception)) {
+            $this->markTestSkipped('Test does not apply to interface ' . $exception);
+        }
+
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Call to private');
+        new $exception();
     }
 }

--- a/test/ExceptionTest.php
+++ b/test/ExceptionTest.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WebimpressTest\SafeWriter;
 
+use Generator;
 use PHPUnit\Framework\TestCase;
 use Webimpress\SafeWriter\Exception\ExceptionInterface;
 
@@ -13,7 +16,7 @@ use function substr;
 
 class ExceptionTest extends TestCase
 {
-    public function exception()
+    public function exception() : Generator
     {
         $namespace = substr(ExceptionInterface::class, 0, strrpos(ExceptionInterface::class, '\\') + 1);
 
@@ -24,14 +27,13 @@ class ExceptionTest extends TestCase
             yield $class => [$namespace . $class];
         }
     }
+
     /**
      * @dataProvider exception
-     *
-     * @param string $exception
      */
-    public function testExceptionIsInstanceOfExceptionInterface($exception)
+    public function testExceptionIsInstanceOfExceptionInterface(string $exception) : void
     {
-        self::assertContains('Exception', $exception);
+        self::assertStringContainsString('Exception', $exception);
         self::assertTrue(is_a($exception, ExceptionInterface::class, true));
     }
 }

--- a/test/reader.php
+++ b/test/reader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 $file = __DIR__ . '/test.php';
 
 $start = microtime(true);

--- a/test/safe-writer.php
+++ b/test/safe-writer.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 include __DIR__ . '/../vendor/autoload.php';
 
-$data = array_fill(0, mt_rand(10, 100), $_SERVER);
+$data = array_fill(0, random_int(10, 100), $_SERVER);
 
 // sleep for something between 0.5-2s
-usleep(mt_rand(500000, 2000000));
+usleep(random_int(500000, 2000000));
 
 Webimpress\SafeWriter\FileWriter::writeFile(
     __DIR__ . '/test.php',

--- a/test/standard-writer.php
+++ b/test/standard-writer.php
@@ -1,9 +1,11 @@
 <?php
 
-$data = array_fill(0, mt_rand(10, 100), $_SERVER);
+declare(strict_types=1);
+
+$data = array_fill(0, random_int(10, 100), $_SERVER);
 
 // sleep for something between 0.5-2s
-usleep(mt_rand(500000, 2000000));
+usleep(random_int(500000, 2000000));
 
 file_put_contents(
     __DIR__ . '/test.php',


### PR DESCRIPTION
Update all code base to support PHP 7.2+ only.
Add strict type declaration.
Add typehints for all parameters and return types.
`ExceptionInterface` now extends `Throwable`.
All exceptions are not instantiable and theirs method as marked as `@internal`.

I am planning release it as version 2.0.0 but still v1.0 will be maintained.

/cc @Ocramius @morozov