### PR TITLE
Throw exception if `tempnam()` falls back to system temp dir

### DIFF
--- a/src/FileWriter.php
+++ b/src/FileWriter.php
@@ -6,6 +6,7 @@ use function chmod;
 use function dirname;
 use function file_put_contents;
 use function is_writable;
+use function realpath;
 use function rename;
 use function stripos;
 use function tempnam;
@@ -26,9 +27,15 @@ final class FileWriter
     public static function writeFile($file, $content, $chmod = 0666)
     {
         $dir = dirname($file);
-        $tmp = tempnam($dir, 'wsw');
+        // suppress notice thrown when falling back to system temp dir
+        $tmp = @tempnam($dir, 'wsw');
 
         if ($tmp === false) {
+            throw Exception\RuntimeException::unableToCreateTemporaryFile($dir);
+        }
+
+        if (dirname($tmp) !== realpath($dir)) {
+            unlink($tmp);
             throw Exception\RuntimeException::unableToCreateTemporaryFile($dir);
         }
 

--- a/test/FileWriterTest.php
+++ b/test/FileWriterTest.php
@@ -16,6 +16,7 @@ use function is_dir;
 use function is_numeric;
 use function proc_close;
 use function proc_open;
+use function sprintf;
 use function stream_get_contents;
 use function sys_get_temp_dir;
 use function uniqid;
@@ -151,9 +152,10 @@ class FileWriterTest extends TestCase
 
     public function testUnwritableDirThrowsException()
     {
-        $dir = sys_get_temp_dir() . '/unwritable';
+        $dir = __DIR__ . '/unwritable';
         mkdir($dir);
-        chmod($dir, 0400);
+        chmod($dir, 0500);
+
         $this->expectException(RuntimeException::class);
         try {
             FileWriter::writeFile($dir . '/test', 'foo');
@@ -177,8 +179,8 @@ class FileWriterTest extends TestCase
         if (file_exists(__DIR__ . '/test.php')) {
             unlink(__DIR__ . '/test.php');
         }
-        if (is_dir(sys_get_temp_dir() . '/unwritable')) {
-            rmdir(sys_get_temp_dir() . '/unwritable');
+        if (is_dir(__DIR__ . '/unwritable')) {
+            rmdir(__DIR__ . '/unwritable');
         }
 
         parent::tearDown();

--- a/test/FileWriterTest.php
+++ b/test/FileWriterTest.php
@@ -152,16 +152,11 @@ class FileWriterTest extends TestCase
 
     public function testUnwritableDirThrowsException()
     {
-        $dir = __DIR__ . '/unwritable';
-        mkdir($dir);
-        chmod($dir, 0500);
+        $dir = sys_get_temp_dir() . '/unwritable';
+        touch($dir);
 
         $this->expectException(RuntimeException::class);
-        try {
-            FileWriter::writeFile($dir . '/test', 'foo');
-        } finally {
-            chmod($dir, 0700);
-        }
+        FileWriter::writeFile($dir . '/test', 'foo');
     }
 
     public function testRelativeDirectorySaves()
@@ -179,8 +174,8 @@ class FileWriterTest extends TestCase
         if (file_exists(__DIR__ . '/test.php')) {
             unlink(__DIR__ . '/test.php');
         }
-        if (is_dir(__DIR__ . '/unwritable')) {
-            rmdir(__DIR__ . '/unwritable');
+        if (file_exists(sys_get_temp_dir() . '/unwritable')) {
+            unlink(sys_get_temp_dir() . '/unwritable');
         }
 
         parent::tearDown();


### PR DESCRIPTION
Currently if the directory `FileWriter` is asked to write to is unreadable, it will fall back to the system temp directory to create the temporary file and PHP will emit a notice.

This behaviour came up while I was switching `laminas/laminas-config-aggregator` to use `FileWriter`. See https://github.com/laminas/laminas-config-aggregator/pull/4

This PR suppresses the notice and adds a check that the directory the temp file is written to matches the directory of the final file. If they don't match it throws a runtime exception.

I realise this is a breaking change, but if `FileWriter` can't write the temp file to the requested directory, I doubt it'll be able to `rename()` the file there - the exception just comes earlier.