### PR TITLE
Suppress warnings using custom empty error handler instead of `@`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#50](https://github.com/webimpress/safe-writer/pull/50) changes suppressing warnings in `FileWriter::writeFile` method. Custom error handler is used instead of `@`, so it is not possible to handle them outside anymore.
 
 ### Deprecated
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0"?>
 <ruleset>
-    <rule ref="vendor/webimpress/coding-standard/ruleset.xml"/>
+    <rule ref="vendor/webimpress/coding-standard/ruleset.xml">
+        <exclude name="WebimpressCodingStandard.Functions.Throws.AdditionalThrowTag"/>
+        <exclude name="WebimpressCodingStandard.Functions.Throws.WrongNumberExact"/>
+    </rule>
 
     <!-- Display progress -->
     <arg value="p"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,7 +2,6 @@
 <ruleset>
     <rule ref="vendor/webimpress/coding-standard/ruleset.xml">
         <exclude name="WebimpressCodingStandard.Functions.Throws.AdditionalThrowTag"/>
-        <exclude name="WebimpressCodingStandard.Functions.Throws.WrongNumberExact"/>
     </rule>
 
     <!-- Display progress -->

--- a/src/FileWriter.php
+++ b/src/FileWriter.php
@@ -30,8 +30,8 @@ final class FileWriter
 
         // suppress notice thrown when falling back to system temp dir
 
-        /** @psalm-suppress InvalidArgument */
-        set_error_handler(static function () : void {
+        set_error_handler(static function () : bool {
+            return true;
         });
 
         try {

--- a/src/FileWriter.php
+++ b/src/FileWriter.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Webimpress\SafeWriter;
 
+use function assert;
 use function chmod;
 use function dirname;
 use function file_put_contents;
+use function is_string;
 use function is_writable;
 use function realpath;
 use function rename;
+use function restore_error_handler;
+use function set_error_handler;
 use function stripos;
 use function tempnam;
 use function umask;
@@ -25,12 +29,17 @@ final class FileWriter
     public static function writeFile(string $file, string $content, int $chmod = 0666) : void
     {
         $dir = dirname($file);
+
         // suppress notice thrown when falling back to system temp dir
-        $tmp = @tempnam($dir, 'wsw');
+        $tmp = self::suppress(static function () use ($dir) {
+            return tempnam($dir, 'wsw');
+        });
 
         if ($tmp === false) {
             throw Exception\RuntimeException::unableToCreateTemporaryFile($dir);
         }
+
+        assert(is_string($tmp));
 
         if (dirname($tmp) !== realpath($dir)) {
             unlink($tmp);
@@ -48,13 +57,31 @@ final class FileWriter
         }
 
         // On windows try again if rename was not successful but target file is writable.
-        while (@rename($tmp, $file) === false) {
+        while (self::suppress(static function () use ($tmp, $file) {
+            return rename($tmp, $file);
+        }) === false) {
             if (is_writable($file) && stripos(PHP_OS, 'WIN') === 0) {
                 continue;
             }
 
             unlink($tmp);
             throw Exception\RenameException::unableToMoveFile($tmp, $file);
+        }
+    }
+
+    /**
+     * @return mixed
+     */
+    private static function suppress(callable $func)
+    {
+        /** @psalm-suppress InvalidArgument */
+        set_error_handler(static function () : void {
+        });
+
+        try {
+            return $func();
+        } finally {
+            restore_error_handler();
         }
     }
 }

--- a/src/FileWriter.php
+++ b/src/FileWriter.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Webimpress\SafeWriter;
 
-use function assert;
 use function chmod;
 use function dirname;
 use function file_put_contents;
-use function is_string;
 use function is_writable;
 use function realpath;
 use function rename;
@@ -31,55 +29,42 @@ final class FileWriter
         $dir = dirname($file);
 
         // suppress notice thrown when falling back to system temp dir
-        $tmp = self::suppress(static function () use ($dir) {
-            return tempnam($dir, 'wsw');
-        });
 
-        if ($tmp === false) {
-            throw Exception\RuntimeException::unableToCreateTemporaryFile($dir);
-        }
-
-        assert(is_string($tmp));
-
-        if (dirname($tmp) !== realpath($dir)) {
-            unlink($tmp);
-            throw Exception\RuntimeException::unableToCreateTemporaryFile($dir);
-        }
-
-        if (file_put_contents($tmp, $content) === false) {
-            unlink($tmp);
-            throw Exception\WriteContentException::unableToWriteContent($tmp);
-        }
-
-        if (chmod($tmp, $chmod & ~umask()) === false) {
-            unlink($tmp);
-            throw Exception\ChmodException::unableToChangeChmod($tmp);
-        }
-
-        // On windows try again if rename was not successful but target file is writable.
-        while (self::suppress(static function () use ($tmp, $file) {
-            return rename($tmp, $file);
-        }) === false) {
-            if (is_writable($file) && stripos(PHP_OS, 'WIN') === 0) {
-                continue;
-            }
-
-            unlink($tmp);
-            throw Exception\RenameException::unableToMoveFile($tmp, $file);
-        }
-    }
-
-    /**
-     * @return mixed
-     */
-    private static function suppress(callable $func)
-    {
         /** @psalm-suppress InvalidArgument */
         set_error_handler(static function () : void {
         });
 
         try {
-            return $func();
+            $tmp = tempnam($dir, 'wsw');
+
+            if ($tmp === false) {
+                throw Exception\RuntimeException::unableToCreateTemporaryFile($dir);
+            }
+
+            if (dirname($tmp) !== realpath($dir)) {
+                unlink($tmp);
+                throw Exception\RuntimeException::unableToCreateTemporaryFile($dir);
+            }
+
+            if (file_put_contents($tmp, $content) === false) {
+                unlink($tmp);
+                throw Exception\WriteContentException::unableToWriteContent($tmp);
+            }
+
+            if (chmod($tmp, $chmod & ~umask()) === false) {
+                unlink($tmp);
+                throw Exception\ChmodException::unableToChangeChmod($tmp);
+            }
+
+            // On windows try again if rename was not successful but target file is writable.
+            while (rename($tmp, $file) === false) {
+                if (is_writable($file) && stripos(PHP_OS, 'WIN') === 0) {
+                    continue;
+                }
+
+                unlink($tmp);
+                throw Exception\RenameException::unableToMoveFile($tmp, $file);
+            }
         } finally {
             restore_error_handler();
         }

--- a/test/FileWriterTest.php
+++ b/test/FileWriterTest.php
@@ -162,8 +162,7 @@ class FileWriterTest extends TestCase
 
     public function testUnwritableDirThrowsExceptionWhenUsingCustomErrorHandler() : void
     {
-        /** @psalm-suppress InvalidArgument */
-        set_error_handler(static function () : void {
+        set_error_handler(static function () : bool {
             throw new ErrorException();
         });
 

--- a/test/FileWriterTest.php
+++ b/test/FileWriterTest.php
@@ -162,9 +162,10 @@ class FileWriterTest extends TestCase
 
     public function testUnwritableDirThrowsExceptionWhenUsingCustomErrorHandler() : void
     {
-        set_error_handler(static function () : bool {
+        $errorHandler = static function () : bool {
             throw new ErrorException();
-        });
+        };
+        set_error_handler($errorHandler);
 
         $dir = sys_get_temp_dir() . '/unwritable';
         touch($dir);
@@ -173,6 +174,9 @@ class FileWriterTest extends TestCase
         try {
             FileWriter::writeFile($dir . '/test', 'foo');
         } finally {
+            self::assertSame($errorHandler, set_error_handler(static function () : bool {
+                return true;
+            }));
             restore_error_handler();
         }
     }


### PR DESCRIPTION
Fixes #49

When we have a custom error handler around writeFile then the warning
can be handled in case directory os not writable, because warnings were
suppressed by `@` not a custom (empty) error handler.