### PR TITLE
Make it easier to copy the command in GitHub interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ the same file is written multiple times in a short time period.
 Using composer:
 
 ```console
-$ composer require webimpress/safe-writer
+composer require webimpress/safe-writer
 ```
 
 ## Usage


### PR DESCRIPTION
Will remove the `$` from the composer require command to make it easier to just click the copy button in the GitHub interface

![image](https://user-images.githubusercontent.com/2412177/153162513-ff2b1585-eb55-4067-9246-e5291e086601.png)
